### PR TITLE
Feature flag to describe for whom it's enabled for.

### DIFF
--- a/src/Lib.FeatureConfig/Feature.cs
+++ b/src/Lib.FeatureConfig/Feature.cs
@@ -4,6 +4,8 @@
     public class Feature
     {
         public string Name { get; set; }
+
+        public string For { get; set; }
         public DateTime? StartDate { get; set; }
         public DateTime? EndDate { get; set; }
     }

--- a/src/Lib.FeatureConfig/FeaturesService.cs
+++ b/src/Lib.FeatureConfig/FeaturesService.cs
@@ -29,7 +29,7 @@ namespace Lib.FeatureConfig
 
         }
 
-        public bool IsEnabled(string featureName)
+        public bool IsEnabled(string featureName, string forWho = "")
         {
             if (_features == null) return false;
 
@@ -43,6 +43,11 @@ namespace Lib.FeatureConfig
 
             if (feature == null) return false;
 
+            var featureFor = feature.For?.Trim();
+            if (!string.IsNullOrEmpty(featureFor) && !featureFor.Equals(forWho.Trim()))
+            {
+                return false;
+            }
             DateTime now = DateTime.Now;
 
             if (feature.StartDate == null && feature.EndDate == null)

--- a/src/Lib.FeatureConfig/IFeatureService.cs
+++ b/src/Lib.FeatureConfig/IFeatureService.cs
@@ -2,6 +2,6 @@
 {
     public interface IFeatureService
     {
-        bool IsEnabled(string featureName);
+        bool IsEnabled(string featureName,string forWho="");
     }
 }

--- a/src/Lib.FeatureConfigTest/FeatureConfigTests.cs
+++ b/src/Lib.FeatureConfigTest/FeatureConfigTests.cs
@@ -80,5 +80,148 @@ namespace Lib.FeatureConfigTest
 
             Assert.True(result);
         }
+
+        [Fact]
+        public void FeatureForWithStartEndDate1_Test()
+        {
+            FeaturesService fs = new FeaturesService("features.json");
+            fs._features = new System.Collections.Generic.List<Feature>();
+            fs._features.Add(new Feature
+            {
+                Name = "featurewithstartenddate",
+                For="Mike",
+                StartDate = DateTime.Now.Add(new TimeSpan(-2, 0, 0, 0)),
+                EndDate = DateTime.Now.Add(new TimeSpan(1, 0, 0, 0)),
+            });
+
+            var result = fs.IsEnabled("featurewithstartenddate","Mike");
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void FeatureForWithStartEndDate2_Test()
+        {
+            FeaturesService fs = new FeaturesService("features.json");
+            fs._features = new System.Collections.Generic.List<Feature>();
+            fs._features.Add(new Feature
+            {
+                Name = "featurewithstartenddate",
+                For = "Mike",
+                StartDate = DateTime.Now.Add(new TimeSpan(-2, 0, 0, 0)),
+                EndDate = DateTime.Now.Add(new TimeSpan(1, 0, 0, 0)),
+            });
+
+            var result = fs.IsEnabled("featurewithstartenddate", "Mik");
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void FeatureForWithStartEndDate3_Test()
+        {
+            FeaturesService fs = new FeaturesService("features.json");
+            fs._features = new System.Collections.Generic.List<Feature>();
+            fs._features.Add(new Feature
+            {
+                Name = "featurewithstartenddate",
+                For = "Mike",
+                StartDate = DateTime.Now.Add(new TimeSpan(-2, 0, 0, 0)),
+                EndDate = DateTime.Now.Add(new TimeSpan(1, 0, 0, 0)),
+            });
+
+            var result = fs.IsEnabled("featurewithstartenddate", "");
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void FeatureForWithStartEndDate4_Test()
+        {
+            FeaturesService fs = new FeaturesService("features.json");
+            fs._features = new System.Collections.Generic.List<Feature>();
+            fs._features.Add(new Feature
+            {
+                Name = "featurewithstartenddate",
+                For = "Mike",
+                StartDate = DateTime.Now.Add(new TimeSpan(-2, 0, 0, 0)),
+                EndDate = DateTime.Now.Add(new TimeSpan(1, 0, 0, 0)),
+            });
+
+            var result = fs.IsEnabled("featurewithstartenddate", "    ");
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void FeatureForWithStartEndDate5_Test()
+        {
+            FeaturesService fs = new FeaturesService("features.json");
+            fs._features = new System.Collections.Generic.List<Feature>();
+            fs._features.Add(new Feature
+            {
+                Name = "featurewithstartenddate",
+                For = "Mike",
+                StartDate = DateTime.Now.Add(new TimeSpan(-2, 0, 0, 0)),
+                EndDate = DateTime.Now.Add(new TimeSpan(1, 0, 0, 0)),
+            });
+
+            var result = fs.IsEnabled("featurewithstartenddate", "    Mike");
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void FeatureForWithStartEndDate6_Test()
+        {
+            FeaturesService fs = new FeaturesService("features.json");
+            fs._features = new System.Collections.Generic.List<Feature>();
+            fs._features.Add(new Feature
+            {
+                Name = "featurewithstartenddate",
+                For="       ",
+                StartDate = DateTime.Now.Add(new TimeSpan(-2, 0, 0, 0)),
+                EndDate = DateTime.Now.Add(new TimeSpan(1, 0, 0, 0)),
+            });
+
+            var result = fs.IsEnabled("featurewithstartenddate", "Mike");
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void FeatureForWithStartEndDate7_Test()
+        {
+            FeaturesService fs = new FeaturesService("features.json");
+            fs._features = new System.Collections.Generic.List<Feature>();
+            fs._features.Add(new Feature
+            {
+                Name = "featurewithstartenddate",
+                StartDate = DateTime.Now.Add(new TimeSpan(-2, 0, 0, 0)),
+                EndDate = DateTime.Now.Add(new TimeSpan(1, 0, 0, 0)),
+            });
+
+            var result = fs.IsEnabled("featurewithstartenddate", "Mike");
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void FeatureForWithStartEndDate8_Test()
+        {
+            FeaturesService fs = new FeaturesService("features.json");
+            fs._features = new System.Collections.Generic.List<Feature>();
+            fs._features.Add(new Feature
+            {
+                Name = "featurewithstartenddate",
+                For = "Mike",
+                StartDate = DateTime.Now.Add(new TimeSpan(-2, 0, 0, 0)),
+                EndDate = DateTime.Now.Add(new TimeSpan(1, 0, 0, 0)),
+            });
+
+            var result = fs.IsEnabled("featurewithstartenddate", "    MIKE");
+
+            Assert.False(result);
+        }
     }
 }


### PR DESCRIPTION
Features should have an extra flag so that, beside date also some other keywords can be checked, if it's enabled or not.

Like;
``
    feature.IsEnabled("somefeature","Mike");
``

So that; if a web app. has "user" based operations it can be done.

This request may be improved as more detailed checked with regex. So far, to be easy and quick it is just simple equality check.
